### PR TITLE
Add standalone Dockerfile

### DIFF
--- a/install/Dockerfile.tiledb
+++ b/install/Dockerfile.tiledb
@@ -1,6 +1,23 @@
-FROM tiledb_vs
+FROM continuumio/miniconda3:4.10.3
 
-RUN mamba install -y ansicolors docker-py h5py matplotlib numpy pyyaml psutil scipy scikit-learn jinja2 pandas
+ARG VERSION=0.0.1
+ARG TILEDB_VERSION=2.15.3
+ARG COMPILER="cxx-compiler c-compiler"
+#ARG COMPILER="clang"
+
+WORKDIR /tmp/
+
+RUN apt-get update && apt-get install -y wget build-essential libarchive-dev
+RUN conda config --prepend channels conda-forge
+
+# Install mamba for faster installations
+RUN conda install mamba
+
+RUN mamba install -y ansicolors docker-py h5py matplotlib numpy pyyaml psutil scipy scikit-learn jinja2 pandas \
+    tiledb tiledb==${TILEDB_VERSION} cmake pybind11 pytest c-compiler cxx-compiler ninja openblas-devel "pip>22"
+
+RUN . ~/.bashrc && pip install --no-cache-dir \
+    "tiledb-vector-search@git+https://github.com/TileDB-Inc/TileDB-Vector-Search@${VERSION}#egg=tiledb-vector-search&subdirectory=apis/python"
 
 WORKDIR /home/app
 COPY run_algorithm.py ./

--- a/install/Dockerfile.tiledb
+++ b/install/Dockerfile.tiledb
@@ -1,7 +1,7 @@
 FROM continuumio/miniconda3:4.10.3
 
-ARG VERSION=0.0.1
-ARG TILEDB_VERSION=2.15.3
+ARG VERSION=0.0.9
+ARG TILEDB_VERSION=2.16.1
 ARG COMPILER="cxx-compiler c-compiler"
 #ARG COMPILER="clang"
 

--- a/install/Dockerfile.tiledb.local
+++ b/install/Dockerfile.tiledb.local
@@ -1,0 +1,7 @@
+FROM tiledb_vs
+
+RUN mamba install -y ansicolors docker-py h5py matplotlib numpy pyyaml psutil scipy scikit-learn jinja2 pandas
+
+WORKDIR /home/app
+COPY run_algorithm.py ./
+ENTRYPOINT ["python", "-u", "run_algorithm.py"]


### PR DESCRIPTION
Usage for standalone build:
```
docker build -f install/Dockerfile.tiledb . -t billion-scale-benchmark-tiledb
```

Usage for standalone build derived from local `tiledb_ts` tag of [this Dockerfile](https://github.com/TileDB-Inc/TileDB-Vector-Search/blob/main/Dockerfile)
```
docker build -f install/Dockerfile.tiledb.local . -t billion-scale-benchmark-tiledb
```